### PR TITLE
fix typo

### DIFF
--- a/store/localization-en.yml
+++ b/store/localization-en.yml
@@ -19,7 +19,7 @@ protocol: Protocol
 
 # Lisans
 license_key: License Key
-key: Anahtar
+key: Key
 
 # Logins
 url: Website
@@ -27,7 +27,7 @@ url: Website
 # Bank Accounts
 bank_name: Bank Name
 bank_code: Bank Code
-account_name: Acount Name
+account_name: Account Name
 account_number: Account Number
 iban: IBAN
 currency: Currency


### PR DESCRIPTION
Hello, I found two Typos in the location-en. 

I see "Signin"  i think that could be changed to "Log in" or "Sign up" 

Best regards 